### PR TITLE
Australis fix

### DIFF
--- a/content/faviconizetab.css
+++ b/content/faviconizetab.css
@@ -8,19 +8,27 @@ tab[faviconized="true"] .tab-text-stack * {
 }
 
 .tabbrowser-tabs tab[faviconized="true"][fadein="true"] {
-   min-width: 36px !important;
-   max-width: 52px !important;
+   min-width: 34px !important;
+   max-width: 50px !important;
 }
 
-.tabbrowser-tabs tab[faviconized="true"] .tab-icon-image,
-.tabbrowser-tabs tab[faviconized="true"] .tab-close-button {
-   margin-left: 3px;
+.tabbrowser-tabs tab[faviconized="true"][fadein="true"] .tab-icon-image  {
+   margin-left: 0px;
+}
+
+.tabbrowser-tabs tab[faviconized="true"][fadein="true"]:not([busy="true"]):not([progress="true"]) .tab-icon-image  {
+   display: inline;
+}
+
+.tabbrowser-tabs tab[faviconized="true"] .tab-throbber,
+.tabbrowser-tabs tab[faviconized="true"] .tab-icon-image  {
+   -moz-margin-end: 0px;
 }
 
 .tabbrowser-tabs[closebuttons="never"] tab[faviconized="true"][fadein="true"],
 .tabbrowser-tabs[closebuttons="activetab"] tab[faviconized="true"][fadein="true"]:not([selected="true"]),
 .tabbrowser-tabs[favhideclose="true"] tab[faviconized="true"][fadein="true"] {
-   max-width: 36px !important;
+   max-width: 34px !important;
 }
 
 .tabbrowser-tabs[favhideclose="true"] tab[faviconized="true"] .tab-close-button {


### PR DESCRIPTION
## purpose

this patch's purpose is
- changing the tab look to the Australis pinned tab look
- showing defaultFavicon.png when the page has no favicon
## reference

my reference is
- https://github.com/mozilla/gecko-dev/blob/master/browser/base/content/tabbrowser.xml
- https://github.com/mozilla/gecko-dev/blob/master/browser/themes/shared/tabs.inc.css
- https://github.com/mozilla/gecko-dev/blob/master/browser/base/content/browser.css
