### PR TITLE
Fix: Does not remember tab states after restart #13

### DIFF
--- a/content/faviconizetab.js
+++ b/content/faviconizetab.js
@@ -26,7 +26,7 @@ var faviconize = {
       tab.minWidth  = '';
       tab.maxWidth  = '';
 
-      if(this.session) this.session.setTabValue(tab, 'faviconized', true);
+      if(this.session) this.session.setTabValue(tab, 'faviconized', '1');
    },
 
    disable: function(tab) {


### PR DESCRIPTION
Problem has been caused by changes in SessionStore API, which is now only accepts strings as values.

Error message:

JavaScript error: resource:///modules/sessionstore/SessionStore.jsm, line 1726: TypeError: setTabValue only accepts string values
JavaScript error: chrome://faviconizetab/content/faviconizetab.js, line 33: NS_ERROR_XPC_JAVASCRIPT_ERROR_WITH_DETAILS: [JavaScript Error: "setTabValue only accepts string values" {
file: "resource:///modules/sessionstore/SessionStore.jsm" line: 1726}]'[JavaScript Error: "setTabValue only accepts string values" {file: "resource:///modules/sessionstore/SessionSt
ore.jsm" line: 1726}]' when calling method: [nsISessionStore::setTabValue]
